### PR TITLE
Bug: NFT/ENS separation based on ENS Contract instead of name

### DIFF
--- a/src/hooks/useNfts.ts
+++ b/src/hooks/useNfts.ts
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react'
 import type { Chain } from 'wagmi'
 import type { Nft } from '../types'
 
+const ENS_CONTRACT_ADDRESS = '0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85';
+
 type Response = {
   nfts: Nft[]
   ensNames: Nft[]
@@ -33,12 +35,12 @@ export default function useNfts(address?: string, chain?: Chain): Response {
           const data = await response.json()
 
           newNFTs = newNFTs.concat(
-            data.assets.filter((nft: Nft) => nft.asset_contract.name !== 'ENS')
+            data.assets.filter((nft: Nft) => nft.asset_contract.address !== ENS_CONTRACT_ADDRESS)
           )
           setNfts(nfts.concat(newNFTs))
 
           newEnsNames = newEnsNames.concat(
-            data.assets.filter((nft: Nft) => nft.asset_contract.name === 'ENS')
+            data.assets.filter((nft: Nft) => nft.asset_contract.address === ENS_CONTRACT_ADDRESS)
           )
           setEnsNames(ensNames.concat(newEnsNames))
 

--- a/src/pages/ens.tsx
+++ b/src/pages/ens.tsx
@@ -196,9 +196,9 @@ function TransactionModal({
 
   const { chain } = useNetwork()
   const { address } = useAccount()
-  const { data: ensName } = useEnsName({ address })
+  const { data: ensName } = useEnsName({ address, chainId: chain?.id })
   const { data: ensResolver } = useEnsResolver({
-    name: ensName ?? undefined,
+    name: ensName ?? undefined, chainId: chain?.id
   })
 
   const nodehash = ensName && hash(ensName)


### PR DESCRIPTION
On Goerli testnet, the ENS contract name is `Unidentified contract` in contrast of the mainnet's `ENS`.

Changing the useNfts check for ENS to contract address instead of name.